### PR TITLE
use no-restricted-properties to prevent console

### DIFF
--- a/packages/eslint-config-dvpnt/base.js
+++ b/packages/eslint-config-dvpnt/base.js
@@ -17,6 +17,11 @@ module.exports = {
 	rules: {
 		// Possible Errors
 		'no-console': 'error',
+		'no-restricted-properties': [
+			'error',
+			{object: 'window', property: 'console'},
+			{object: 'global', property: 'console'}
+		],
 		'no-extra-parens': [
 			'error',
 			'all',


### PR DESCRIPTION
https://github.com/vladimir-polyakov/camstat/pull/456/files#diff-bb59258fc27c76217960da6d847c3f38R53
![image](https://user-images.githubusercontent.com/16390359/92125158-59fa9e80-ee07-11ea-8619-57b9c03392b8.png)
Оказывается, можно обмануть линтёр и всё равно использовать `console.log`. В этом пр-е это чинится.